### PR TITLE
Nonchanging percepts

### DIFF
--- a/src/DUWOagent/perceptEvents.mod2g
+++ b/src/DUWOagent/perceptEvents.mod2g
@@ -41,14 +41,21 @@ module perceptEvents {
 	if percept(zones(X)), bel(zones(Y)), bel(not(X == Y))
 			then delete(zones(Y)) + insert(zones(X)).
 	
-	%% Delete all current indicators when we percept new indicators.
-	forall percept(indicators(_)), bel(indicator(ID,CurrentValue,TargetValue))
-			do delete(indicator(ID,CurrentValue,TargetValue)).
-	
 	%% Percepts a list of all indicators ([<indID>, <currentValue>, <targetValue>])
-	%% and insert our indicators separately.
+	%% and insert our indicators separately when not already present in belief base.
 	forall percept(indicators(X)),
 			bel(member(indicator(ID,CurrentValue,TargetValue),X),
-			indicatorWeight(ID,_,_)) % Only insert our indicators.
+			indicatorWeight(ID,_,_)), % Only insert our indicators.
+			bel(not(indicator(ID,OldValue,TargetValue)))
 			do insert(indicator(ID,CurrentValue,TargetValue)).
+	
+	%% Percepts a list of all indicators ([<indID>, <currentValue>, <targetValue>])
+	%% and update our indicators.
+	forall percept(indicators(X)),
+			bel(member(indicator(ID,CurrentValue,TargetValue),X),
+			indicatorWeight(ID,_,_)), % Only insert our indicators.
+			bel(indicator(ID,OldValue,TargetValue)),
+			bel(not(OldValue == CurrentValue))
+			do delete(indicator(ID,OldValue,TargetValue))
+			+ insert(indicator(ID,CurrentValue,TargetValue)).
 }

--- a/src/DUWOagent/perceptEvents.mod2g
+++ b/src/DUWOagent/perceptEvents.mod2g
@@ -7,7 +7,7 @@ module perceptEvents {
 	%% When a percept is obtained, update the corresponding belief. %%
 	
 	%% Percepts a list of all stakeholders ([<id>, <name>, <income>, <start_budget>]).
-	if percept(stakeholders(X)), bel(stakeholders(Y))
+	if percept(stakeholders(X)), bel(stakeholders(Y)), bel(not(X == Y))
 			then delete(stakeholders(Y)) + insert(stakeholders(X)).
 	
 	%% Percepts the ID of the stakeholder the virtual human is.
@@ -26,19 +26,19 @@ module perceptEvents {
 			do insert(stakeholder(ID,Name)).
 	
 	%% Percepts a list of all settings ([<setting>]).
-	if percept(settings(X)), bel(settings(Y))
+	if percept(settings(X)), bel(settings(Y)), bel(not(X == Y))
 			then delete(settings(Y)) + insert(settings(X)).
 	
 	%% Percepts a list of all functions ([<name>, <id>, [<category>]]).
-	if percept(functions(X)), bel(functions(Y))
+	if percept(functions(X)), bel(functions(Y)), bel(not(X == Y))
 			then delete(functions(Y)) + insert(functions(X)).
 	
 	%% Percepts a list of all buildings ([building(<id>, <name>, <ownerID>, <constructionYear>, [<category>], <functionID>, <amountOfFloors>)]).
-	if percept(buildings(X)), bel(buildings(Y))
+	if percept(buildings(X)), bel(buildings(Y)), bel(not(X == Y))
 			then delete(buildings(Y)) + insert(buildings(X)).
 	
 	%% Percepts a list of all zones ([zone(<id>, <name>, <maxFloors>, <size>, [<allowedCategory>])]).
-	if percept(zones(X)), bel(zones(Y))
+	if percept(zones(X)), bel(zones(Y)), bel(not(X == Y))
 			then delete(zones(Y)) + insert(zones(X)).
 	
 	%% Delete all current indicators when we percept new indicators.

--- a/src/DUWOagent/perceptEvents.mod2g
+++ b/src/DUWOagent/perceptEvents.mod2g
@@ -26,11 +26,11 @@ module perceptEvents {
 			do insert(stakeholder(ID,Name)).
 	
 	%% Percepts a list of all settings ([<setting>]).
-	if percept(settings(X)), bel(settings(Y)), bel(not(X == Y))
+	if percept(settings(X)), bel(settings(Y))
 			then delete(settings(Y)) + insert(settings(X)).
 	
 	%% Percepts a list of all functions ([<name>, <id>, [<category>]]).
-	if percept(functions(X)), bel(functions(Y)), bel(not(X == Y))
+	if percept(functions(X)), bel(functions(Y))
 			then delete(functions(Y)) + insert(functions(X)).
 	
 	%% Percepts a list of all buildings ([building(<id>, <name>, <ownerID>, <constructionYear>, [<category>], <functionID>, <amountOfFloors>)]).


### PR DESCRIPTION
Beliefs now only update when the virtual human gets a percept that is different than what it beliefs. This makes noticing updates in the belief base easier, since there is less deleting and inserting going on.

User story:
As a developer, I want to have a clear understanding about the internal state of the virtual human, so that the virtual human can be debugged more easily.
